### PR TITLE
Fixed solution directories so they can be managed in the IDE

### DIFF
--- a/SPDX.CodeAnalysis.sln
+++ b/SPDX.CodeAnalysis.sln
@@ -3,13 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.13.35931.197
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
-	ProjectSection(SolutionItems) = preProject
-		.build\Ensure-Powershell-Dependencies.ps1 = .build\Ensure-Powershell-Dependencies.ps1
-		.build\nuget.props = .build\nuget.props
-		version.json = version.json
-		.build\WildcardVersionSupport.targets = .build\WildcardVersionSupport.targets
-	EndProjectSection
+Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = ".github", "proj\.github.msbuildproj", "{873A3BE7-3364-F423-9686-FFB58C0896C4}"
+EndProject
+Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "docs", "proj\docs.msbuildproj", "{F1CC6D09-070B-440A-BDA2-C7A8037076ED}"
+EndProject
+Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "eng", "proj\eng.msbuildproj", "{9A1C280A-5010-45E9-9EC8-B09F0F9517A2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C2EF017A-5599-40FA-A1C4-E30C8587B058}"
 	ProjectSection(SolutionItems) = preProject
@@ -62,7 +60,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SPDX.CodeAnalysis.CodeFixes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SPDX.CodeAnalysis.CodeFixes.Common", "src\SPDX.CodeAnalysis.CodeFixes.Common\SPDX.CodeAnalysis.CodeFixes.Common.csproj", "{915EF32A-E09C-4831-BAD4-085C5327093B}"
 EndProject
-Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = ".github", "proj\.github.msbuildproj", "{873A3BE7-3364-F423-9686-FFB58C0896C4}"
+Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "proj", "proj\proj.msbuildproj", "{4134ADDB-4290-5838-975F-EC45C9E5332F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -70,6 +68,18 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{873A3BE7-3364-F423-9686-FFB58C0896C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{873A3BE7-3364-F423-9686-FFB58C0896C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{873A3BE7-3364-F423-9686-FFB58C0896C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{873A3BE7-3364-F423-9686-FFB58C0896C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1CC6D09-070B-440A-BDA2-C7A8037076ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1CC6D09-070B-440A-BDA2-C7A8037076ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1CC6D09-070B-440A-BDA2-C7A8037076ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1CC6D09-070B-440A-BDA2-C7A8037076ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9A1C280A-5010-45E9-9EC8-B09F0F9517A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A1C280A-5010-45E9-9EC8-B09F0F9517A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A1C280A-5010-45E9-9EC8-B09F0F9517A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A1C280A-5010-45E9-9EC8-B09F0F9517A2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4F5BF1EB-3758-4093-922E-8C37ED8393FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4F5BF1EB-3758-4093-922E-8C37ED8393FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F5BF1EB-3758-4093-922E-8C37ED8393FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -114,10 +124,10 @@ Global
 		{915EF32A-E09C-4831-BAD4-085C5327093B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{915EF32A-E09C-4831-BAD4-085C5327093B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{915EF32A-E09C-4831-BAD4-085C5327093B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{873A3BE7-3364-F423-9686-FFB58C0896C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{873A3BE7-3364-F423-9686-FFB58C0896C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{873A3BE7-3364-F423-9686-FFB58C0896C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{873A3BE7-3364-F423-9686-FFB58C0896C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4134ADDB-4290-5838-975F-EC45C9E5332F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4134ADDB-4290-5838-975F-EC45C9E5332F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4134ADDB-4290-5838-975F-EC45C9E5332F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4134ADDB-4290-5838-975F-EC45C9E5332F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/proj/Directory.Build.props
+++ b/proj/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  
+  <PropertyGroup>
+    <BaseOutputPath>$(MSBuildThisFileDirectory)..\_artifacts\noop\$(MSBuildProjectName)\</BaseOutputPath>
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\_artifacts\noop\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <OutputPath>$(BaseOutputPath)</OutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
+  </PropertyGroup>
+</Project>

--- a/proj/docs.msbuildproj
+++ b/proj/docs.msbuildproj
@@ -11,6 +11,6 @@
     <SkipGitVersioning>true</SkipGitVersioning>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="../.github/**/*.*" Exclude="../.github/obj/**/*;../.github/bin/**/*"/>
+    <Content Include="../docs/**/*.*" Exclude="../docs/obj/**/*;../docs/bin/**/*"/>
   </ItemGroup>
 </Project>

--- a/proj/eng.msbuildproj
+++ b/proj/eng.msbuildproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- Required, but irrelevant -->
     <TargetFramework>netstandard2.0</TargetFramework>
-
+    
     <!-- Do not run on solution builds -->
     <OutputType>None</OutputType>
     <IsPackable>false</IsPackable>
@@ -11,6 +11,6 @@
     <SkipGitVersioning>true</SkipGitVersioning>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="../.github/**/*.*" Exclude="../.github/obj/**/*;../.github/bin/**/*"/>
+    <Content Include="../eng/**/*.*" Exclude="../eng/obj/**/*;../eng/bin/**/*"/>
   </ItemGroup>
 </Project>

--- a/proj/proj.msbuildproj
+++ b/proj/proj.msbuildproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- Required, but irrelevant -->
     <TargetFramework>netstandard2.0</TargetFramework>
-
+    
     <!-- Do not run on solution builds -->
     <OutputType>None</OutputType>
     <IsPackable>false</IsPackable>
@@ -11,6 +11,6 @@
     <SkipGitVersioning>true</SkipGitVersioning>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="../.github/**/*.*" Exclude="../.github/obj/**/*;../.github/bin/**/*"/>
+    <None Include="Directory.Build.props" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixed `.github`, `docs`, and `eng` directories so the files on disk can be managed inside Visual Studio without producing any build activity.